### PR TITLE
stop/restart ntpd if present to change server time (fix bug #5599)

### DIFF
--- a/lib/leap_cli/remote/tasks.rb
+++ b/lib/leap_cli/remote/tasks.rb
@@ -38,12 +38,12 @@ task :install_prerequisites, :max_hosts => MAX_HOSTS do
     run "apt-get update"
   end
   leap.log :updating, "server time" do
-    run "test -f /etc/init.d/ntp || #{apt_get} install ntp && /etc/init.d/ntp stop"
+    run "( test -f /etc/init.d/ntp && /etc/init.d/ntp stop ) || true"
     run "test -f /usr/sbin/ntpdate || #{apt_get} install ntpdate"
     leap.log :running, "ntpdate..." do
       run "test -f /usr/sbin/ntpdate && ntpdate 0.debian.pool.ntp.org 1.debian.pool.ntp.org 2.debian.pool.ntp.org 3.debian.pool.ntp.org"
     end
-    run "test -f /etc/init.d/ntp && /etc/init.d/ntp start"
+    run "( test -f /etc/init.d/ntp && /etc/init.d/ntp start ) || true"
   end
   leap.log :installing, "required packages" do
     run "#{apt_get} install #{leap.required_packages}"


### PR DESCRIPTION
This will fix bug #5599 without the need to install ntp on debian, as it's going to be installed on a later stage.
