### PR TITLE
Removed conflictive config of net:ssh (Fixes #5696)

### DIFF
--- a/lib/leap_cli/util/remote_command.rb
+++ b/lib/leap_cli/util/remote_command.rb
@@ -50,7 +50,6 @@ module LeapCli; module Util; module RemoteCommand
   #
   def ssh_options
     {
-      :config => "~/.ssh/config",
       :global_known_hosts_file => path(:known_hosts),
       :user_known_hosts_file => '/dev/null',
       :paranoid => true


### PR DESCRIPTION
ssh configuration file value passed directly to open(), not allowing the use of "~/" in the value. as net:ssh defaults to ~/.ssh/config there is no need to define the config file here.
