### PR TITLE
implement optional provider custom puppet support (#6201, #6225)

### DIFF
--- a/lib/leap_cli/commands/deploy.rb
+++ b/lib/leap_cli/commands/deploy.rb
@@ -204,6 +204,21 @@ module LeapCli
           :flags => "-rlt --relative --delete --copy-links"
         }
       end
+      ssh.rsync.update do |server|
+        custom_site = Path.provider + LeapCli::CUSTOM_PUPPET_SITE
+        custom_modules = Path.provider + LeapCli::CUSTOM_PUPPET_MODULES
+        if !file_exists?(custom_site)
+          write_file!(custom_site, "# custom puppet configuration" + "\n" + "tag 'leap_base'" + "\n")
+        end
+        ensure_dir custom_modules
+        ssh.leap.log(Path.provider + LeapCli::CUSTOM_PUPPET_SOURCE + ' -> ' + server.host + ':' + LeapCli::CUSTOM_PUPPET_DESTINATION)
+        {
+          :dest => LeapCli::CUSTOM_PUPPET_DESTINATION,
+          :source => Path.provider + LeapCli::CUSTOM_PUPPET_SOURCE,
+          :chdir => Path.platform,
+          :flags => "-rlt --delete --copy-links"
+        }
+      end
     end
 
     #

--- a/lib/leap_cli/constants.rb
+++ b/lib/leap_cli/constants.rb
@@ -1,6 +1,10 @@
 module LeapCli
 
   PUPPET_DESTINATION = '/srv/leap'
+  CUSTOM_PUPPET_DESTINATION = '/srv/leap/custom-puppet'
+  CUSTOM_PUPPET_SOURCE = '/files/custom-puppet/'
+  CUSTOM_PUPPET_SITE = "#{CUSTOM_PUPPET_SOURCE}/manifests/site.pp"
+  CUSTOM_PUPPET_MODULES = "#{CUSTOM_PUPPET_SOURCE}/modules"
   INITIALIZED_FILE = "#{PUPPET_DESTINATION}/initialized"
   DEFAULT_TAGS = ['leap_base','leap_service']
 


### PR DESCRIPTION
if files/custom-puppet/{manifests,modules} does not exist, it will be
created and files/custom-puppet/manifests/site.pp will be populated with
a comment and necessary tag to apply in the platform.

The site.pp must exist, if it does not, then the import in the
platform/manifest/site.pp will fail.

Any puppet resources put in custom-puppet/manifests/site.pp will be
executed, and any modules placed in custom-puppet/modules will be made
available through the --modulepath parameter to puppet.

This requires the associated platform changes (#6226)
