### PR TITLE
update basebox url closes #5468

### DIFF
--- a/lib/leap_cli/commands/vagrant.rb
+++ b/lib/leap_cli/commands/vagrant.rb
@@ -156,7 +156,7 @@ module LeapCli; module Commands
           if node.vagrant?
             lines << %[  config.vm.define :#{node.name} do |config|]
             lines << %[    config.vm.box = "leap-wheezy"]
-            lines << %[    config.vm.box_url = "https://downloads.leap.se/platform/leap-debian.box"]
+            lines << %[    config.vm.box_url = "https://downloads.leap.se/platform/vagrant/virtualbox/leap-wheezy.box"]
             lines << %[    config.vm.network :hostonly, "#{node.ip_address}", :netmask => "#{netmask}"]
             lines << %[    config.vm.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]]
             lines << %[    config.vm.customize ["modifyvm", :id, "--name", "#{node.name}"]]
@@ -170,7 +170,7 @@ module LeapCli; module Commands
           if node.vagrant?
             lines << %[  config.vm.define :#{node.name} do |config|]
             lines << %[    config.vm.box = "leap-wheezy"]
-            lines << %[    config.vm.box_url = "https://downloads.leap.se/platform/leap-debian.box"]
+            lines << %[    config.vm.box_url = "https://downloads.leap.se/platform/vagrant/virtualbox/leap-wheezy.box"]
             lines << %[    config.vm.network :private_network, ip: "#{node.ip_address}"]
             lines << %[    config.vm.provider "virtualbox" do |v|]
             lines << %[      v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]]


### PR DESCRIPTION
By using 'wheezy' instead of Debian in the url and box name, this is less confusing. At the same time, this makes it easier to support jessie boxes in the near future. The subdirectory virtualbox is to differentiate with the libvirt ones.
